### PR TITLE
Command to always list pane directory files

### DIFF
--- a/Key Bindings.json
+++ b/Key Bindings.json
@@ -1,5 +1,6 @@
 [
 	{ "keys": ["F2"], "command": "flat_view" },
-	{ "keys": ["Ctrl+F2"], "command": "flat_view_filtered" }
+	{ "keys": ["Ctrl+F2"], "command": "flat_view_filtered" },
+	{ "keys": ["Alt+F2"], "command": "flat_view_pane" }
 
 ]

--- a/flat_view/__init__.py
+++ b/flat_view/__init__.py
@@ -31,6 +31,12 @@ class FlatViewFiltered(DirectoryPaneCommand):
 		if ok and text:
 			self.pane.set_path(new_url + '?' + text)
 
+class FlatViewPane(DirectoryPaneCommand):
+	def __call__(self, url=None):
+		if url is None:
+			url = self.pane.get_path()
+		new_url = Flat.scheme + splitscheme(url)[1]
+		self.pane.set_path(new_url)
 
 
 _SEPARATOR = '|'


### PR DESCRIPTION
Added command to list all files in the panes directory regardless of if a folder or file is highlighted. Assigned ALT+F2 for default hotkey.